### PR TITLE
optimize svec and smat functions

### DIFF
--- a/src/Cones/arrayutilities.jl
+++ b/src/Cones/arrayutilities.jl
@@ -184,12 +184,12 @@ function smat_to_svec!(vec::AbstractVector{T}, mat::AbstractMatrix{T}, rt2::Real
     k = 1
     m = size(mat, 1)
     @assert m == size(mat, 2)
-    for j in 1:m, i in 1:j
-        @inbounds if i == j
-            vec[k] = mat[i, j]
-        else
+    @inbounds for j in 1:m
+        for i in 1:j-1
             vec[k] = mat[i, j] * rt2
+            k += 1
         end
+        vec[k] = mat[j, j]
         k += 1
     end
     @assert k == length(vec) + 1
@@ -214,17 +214,15 @@ function _smat_to_svec_complex!(vec, mat, rt2)
     k = 1
     m = size(mat, 1)
     @assert m == size(mat, 2)
-    for j in 1:m, i in 1:j
-        @inbounds if i == j
-            vec[k] = real(mat[i, j])
+    @inbounds for j in 1:m
+        for i in 1:j-1
+            vec[k] = real(mat[i, j]) * rt2
             k += 1
-        else
-            ck = mat[i, j] * rt2
-            vec[k] = real(ck)
-            k += 1
-            vec[k] = -imag(ck)
+            vec[k] = imag(mat[i, j]) * rt2
             k += 1
         end
+        vec[k] = real(mat[j, j])
+        k += 1
     end
     @assert k == length(vec) + 1
     return vec
@@ -239,12 +237,13 @@ function svec_to_smat!(mat::AbstractMatrix{T}, vec::AbstractVector{T}, rt2::Real
     k = 1
     m = size(mat, 1)
     @assert m == size(mat, 2)
-    for j in 1:m, i in 1:j
-        @inbounds if i == j
-            mat[i, j] = vec[k]
-        else
-            mat[i, j] = vec[k] / rt2
+    invrt2 = inv(rt2)
+    @inbounds for j in 1:m
+        for i in 1:j-1
+            mat[i, j] = vec[k] * invrt2
+            k += 1
         end
+        mat[j, j] = vec[k]
         k += 1
     end
     @assert k == length(vec) + 1
@@ -269,14 +268,14 @@ function _svec_to_smat_complex!(mat, vec, rt2)
     k = 1
     m = size(mat, 1)
     @assert m == size(mat, 2)
-    @inbounds for j in 1:m, i in 1:j
-        if i == j
-            mat[i, j] = vec[k]
-            k += 1
-        else
-            mat[i, j] = complex(vec[k], -vec[k + 1]) / rt2
+    invrt2 = inv(rt2)
+    @inbounds for j in 1:m
+        for i in 1:j-1
+            mat[i, j] = complex(vec[k], vec[k + 1]) * invrt2
             k += 2
         end
+        mat[j, j] = vec[k]
+        k += 1
     end
     @assert k == length(vec) + 1
     return mat
@@ -340,12 +339,12 @@ function symm_kron!(
                 for i in 1:(j - 1)
                     a = mat[i, k] * mat[l, j]
                     b = mat[j, k] * mat[l, i]
-                    spectral_kron_element!(skr, row_idx, col_idx, a, b)
+                    spectral_kron_element!(skr, row_idx, col_idx, conj(a), conj(b))
                     row_idx += 2
                 end
                 c = rt2 * mat[j, k] * mat[l, j]
                 skr[row_idx, col_idx] = real(c)
-                skr[row_idx, col_idx + 1] = imag(c)
+                skr[row_idx, col_idx + 1] = -imag(c)
                 row_idx += 1
                 (row_idx > col_idx) && break
             end
@@ -357,7 +356,7 @@ function symm_kron!(
             for i in 1:(j - 1)
                 c = rt2 * mat[i, l] * mat[l, j]
                 skr[row_idx, col_idx] = real(c)
-                skr[row_idx + 1, col_idx] = -imag(c)
+                skr[row_idx + 1, col_idx] = imag(c)
                 row_idx += 2
             end
             skr[row_idx, col_idx] = abs2(mat[j, l])
@@ -384,7 +383,7 @@ function eig_dot_kron!(
     @assert issymmetric(inner) # must be symmetric (wrapper is less efficient)
     rt2i = inv(rt2)
     copyto!(V, vecs') # allows fast column slices
-    scals = (R <: Complex{T} ? [rt2i, rt2i * im] : [rt2i]) # real and imag parts
+    scals = (R <: Complex{T} ? [rt2i, -rt2i * im] : [rt2i]) # real and imag parts
 
     col_idx = 1
     @inbounds for j in 1:size(inner, 1)

--- a/src/Cones/epitrrelentropytri.jl
+++ b/src/Cones/epitrrelentropytri.jl
@@ -579,7 +579,7 @@ function d2zdV2!(
     d = size(vecs, 1)
     V = copyto!(mat, vecs')
     rt2i = inv(rt2)
-    scals = (R <: Complex{T} ? [rt2i, rt2i * im] : [rt2i])
+    scals = (R <: Complex{T} ? [rt2i, -rt2i * im] : [rt2i])
 
     col_idx = 1
     @inbounds for j in 1:d

--- a/src/Cones/matrixepipersquare.jl
+++ b/src/Cones/matrixepipersquare.jl
@@ -261,8 +261,8 @@ function update_hess(cone::MatrixEpiPerSquare)
                 H[row_idx, col_idx] = real(term1) + real(term2)
                 H[row_idx, col_idx + 1] = imag(term1) + imag(term2)
                 if i != j
-                    H[row_idx + 1, col_idx] = imag(term2) - imag(term1)
-                    H[row_idx + 1, col_idx + 1] = real(term1) - real(term2)
+                    H[row_idx + 1, col_idx] = imag(term1) - imag(term2)
+                    H[row_idx + 1, col_idx + 1] = real(term2) - real(term1)
                 end
             else
                 term = Zi[i, k] * ZiW[j, l] + Zi[k, j] * ZiW[i, l]

--- a/src/MathOptInterface/transform.jl
+++ b/src/MathOptInterface/transform.jl
@@ -88,7 +88,7 @@ function rescale_affine(cone::SvecCone, func::VAF{T}, vals::AbstractVector{T}) w
     return vals
 end
 
-# transformation (svec rescaling and real/imag parts reordering) for MOI Hermitian PSD cone not in svec (scaled lower triangle) form
+# transformation (svec rescaling and real/imag parts reordering) for MOI Hermitian PSD cone not in svec (scaled upper triangle) form
 needs_untransform(::MOI.HermitianPositiveSemidefiniteConeTriangle) = true
 
 function untransform_affine(


### PR DESCRIPTION
I wanted to try the `reinterpret` trick I mentioned to @blegat, but it doesn't make any difference. The only thing that mattered was removing the `if` from inside the loop, that gave a 16% speedup. Which is quite nice to have, as `svec` is used in a loop in `eig_dot_kron`, which is the main bottleneck of a couple of cones.

I also removed the complex conjugation from `svec` and `smat`. That is ugly, contradicts the documentation, and is not taken into account by the bridge with the MOI Hermitian PSD cone, so removing it is kind of a bugfix.