### PR TITLE
remove complex conjugation from svec

### DIFF
--- a/src/Cones/arrayutilities.jl
+++ b/src/Cones/arrayutilities.jl
@@ -218,7 +218,7 @@ function _smat_to_svec_complex!(vec, mat, rt2)
         for i in 1:(j - 1)
             vec[k] = real(mat[i, j]) * rt2
             k += 1
-            vec[k] = -imag(mat[i, j]) * rt2
+            vec[k] = imag(mat[i, j]) * rt2
             k += 1
         end
         vec[k] = real(mat[j, j])
@@ -271,7 +271,7 @@ function _svec_to_smat_complex!(mat, vec, rt2)
     invrt2 = inv(rt2)
     @inbounds for j in 1:m
         for i in 1:(j - 1)
-            mat[i, j] = complex(vec[k], -vec[k + 1]) * invrt2
+            mat[i, j] = complex(vec[k], vec[k + 1]) * invrt2
             k += 2
         end
         mat[j, j] = vec[k]
@@ -339,12 +339,12 @@ function symm_kron!(
                 for i in 1:(j - 1)
                     a = mat[i, k] * mat[l, j]
                     b = mat[j, k] * mat[l, i]
-                    spectral_kron_element!(skr, row_idx, col_idx, a, b)
+                    spectral_kron_element!(skr, row_idx, col_idx, conj(a), conj(b))
                     row_idx += 2
                 end
                 c = rt2 * mat[j, k] * mat[l, j]
                 skr[row_idx, col_idx] = real(c)
-                skr[row_idx, col_idx + 1] = imag(c)
+                skr[row_idx, col_idx + 1] = -imag(c)
                 row_idx += 1
                 (row_idx > col_idx) && break
             end
@@ -356,7 +356,7 @@ function symm_kron!(
             for i in 1:(j - 1)
                 c = rt2 * mat[i, l] * mat[l, j]
                 skr[row_idx, col_idx] = real(c)
-                skr[row_idx + 1, col_idx] = -imag(c)
+                skr[row_idx + 1, col_idx] = imag(c)
                 row_idx += 2
             end
             skr[row_idx, col_idx] = abs2(mat[j, l])
@@ -383,7 +383,7 @@ function eig_dot_kron!(
     @assert issymmetric(inner) # must be symmetric (wrapper is less efficient)
     rt2i = inv(rt2)
     copyto!(V, vecs') # allows fast column slices
-    scals = (R <: Complex{T} ? [rt2i, rt2i * im] : [rt2i]) # real and imag parts
+    scals = (R <: Complex{T} ? [rt2i, -rt2i * im] : [rt2i]) # real and imag parts
 
     col_idx = 1
     @inbounds for j in 1:size(inner, 1)

--- a/src/Cones/epitrrelentropytri.jl
+++ b/src/Cones/epitrrelentropytri.jl
@@ -579,7 +579,7 @@ function d2zdV2!(
     d = size(vecs, 1)
     V = copyto!(mat, vecs')
     rt2i = inv(rt2)
-    scals = (R <: Complex{T} ? [rt2i, rt2i * im] : [rt2i])
+    scals = (R <: Complex{T} ? [rt2i, -rt2i * im] : [rt2i])
 
     col_idx = 1
     @inbounds for j in 1:d

--- a/src/Cones/matrixepipersquare.jl
+++ b/src/Cones/matrixepipersquare.jl
@@ -261,8 +261,8 @@ function update_hess(cone::MatrixEpiPerSquare)
                 H[row_idx, col_idx] = real(term1) + real(term2)
                 H[row_idx, col_idx + 1] = imag(term1) + imag(term2)
                 if i != j
-                    H[row_idx + 1, col_idx] = imag(term2) - imag(term1)
-                    H[row_idx + 1, col_idx + 1] = real(term1) - real(term2)
+                    H[row_idx + 1, col_idx] = imag(term1) - imag(term2)
+                    H[row_idx + 1, col_idx + 1] = real(term2) - real(term1)
                 end
             else
                 term = Zi[i, k] * ZiW[j, l] + Zi[k, j] * ZiW[i, l]


### PR DESCRIPTION
This is the contentious part from #852. I think it is worth doing it because

1. The MOI complex PSD bridge doesn't do the conjugation, so this fixes a bug.
2. The little documentation there is about svec contradicts the code; this removes the contradiction.
3. It is ugly.
4. This doesn't change the API, so strictly speaking it is non-breaking. One could nevertheless release a 0.9 version to make sure that nobody's code is broken.
5. The only publicly available package that could possibly be broken by this change is mine. The time to fix this is now, before other packages are created.