### PR TITLE
Remove abstract types from cone definitions

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.6'
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']
+        version: ['1.10', '1']
         os: [ubuntu-latest]
         arch: [x64]
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ MathOptInterface = "1"
 PolynomialRoots = "1"
 Requires = "1"
 SpecialFunctions = "2"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"

--- a/src/Cones/doublynonnegativetri.jl
+++ b/src/Cones/doublynonnegativetri.jl
@@ -40,10 +40,10 @@ mutable struct DoublyNonnegativeTri{T <: Real} <: Cone{T}
     mat2::Matrix{T} # TODO rename to imply mutates fact_mat
     mat3::Matrix{T}
     mat4::Matrix{T} # TODO could remove if we factorize mat instead of mat2, currently mat is not used in any other oracles
-    offdiag_idxs::Any
+    offdiag_idxs::Vector{Int}
     inv_mat::Matrix{T}
     inv_vec::Vector{T}
-    fact_mat::Any
+    fact_mat::Cholesky{T, Matrix{T}}
 
     function DoublyNonnegativeTri{T}(dim::Int; use_dual::Bool = false) where {T <: Real}
         @assert dim >= 1

--- a/src/Cones/epinormspectral.jl
+++ b/src/Cones/epinormspectral.jl
@@ -40,7 +40,7 @@ mutable struct EpiNormSpectral{T <: Real, R <: RealOrComplex{T}} <: Cone{T}
     hess_fact_mat::Symmetric{T, Matrix{T}}
     hess_fact::Factorization{T}
 
-    W_svd::Any
+    W_svd::SVD{R, T, Matrix{R}, Vector{T}}
     s::Vector{T}
     U::Matrix{R}
     Vt::Matrix{R}

--- a/src/Cones/epipersepspectral/epipersepspectral.jl
+++ b/src/Cones/epipersepspectral/epipersepspectral.jl
@@ -56,7 +56,7 @@ mutable struct EpiPerSepSpectral{Q <: ConeOfSquares, T <: Real} <: Cone{T}
     hess_fact_mat::Symmetric{T, Matrix{T}}
     hess_fact::Factorization{T}
 
-    w_view::SubArray{T, 1}
+    w_view::SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int}}, true}
     cache::CSqrCache{T}
 
     function EpiPerSepSpectral{Q, T}(

--- a/src/Cones/epirelentropy.jl
+++ b/src/Cones/epirelentropy.jl
@@ -16,8 +16,8 @@ mutable struct EpiRelEntropy{T <: Real} <: Cone{T}
     use_dual_barrier::Bool
     dim::Int
     w_dim::Int
-    v_idxs::UnitRange{Int64}
-    w_idxs::UnitRange{Int64}
+    v_idxs::UnitRange{Int}
+    w_idxs::UnitRange{Int}
 
     point::Vector{T}
     dual_point::Vector{T}

--- a/src/Cones/epitrrelentropytri.jl
+++ b/src/Cones/epitrrelentropytri.jl
@@ -43,8 +43,8 @@ mutable struct EpiTrRelEntropyTri{T <: Real, R <: RealOrComplex{T}} <: Cone{T}
     W_idxs::UnitRange{Int}
     V::Matrix{R}
     W::Matrix{R}
-    V_fact::Eigen{R}
-    W_fact::Eigen{R}
+    V_fact::Eigen{R, T, Matrix{R}, Vector{T}}
+    W_fact::Eigen{R, T, Matrix{R}, Vector{T}}
     Vi::Matrix{R}
     Wi::Matrix{R}
     W_sim::Matrix{R}

--- a/src/Cones/hypoperlogdettri.jl
+++ b/src/Cones/hypoperlogdettri.jl
@@ -40,7 +40,7 @@ mutable struct HypoPerLogdetTri{T <: Real, R <: RealOrComplex{T}} <: Cone{T}
     ϕ::T
     ζ::T
     mat::Matrix{R}
-    fact_W::Cholesky{R}
+    fact_W::Cholesky{R, Matrix{R}}
     Wi::Matrix{R}
     Wi_vec::Vector{T}
     mat2::Matrix{R}

--- a/src/Cones/hyporootdettri.jl
+++ b/src/Cones/hyporootdettri.jl
@@ -42,7 +42,7 @@ mutable struct HypoRootdetTri{T <: Real, R <: RealOrComplex{T}} <: Cone{T}
     ζ::T
     η::T
     mat::Matrix{R}
-    fact_W::Cholesky{R}
+    fact_W::Cholesky{R, Matrix{R}}
     Wi::Matrix{R}
     Wi_vec::Vector{T}
     tempw::Vector{T}

--- a/src/Cones/matrixepipersquare.jl
+++ b/src/Cones/matrixepipersquare.jl
@@ -46,7 +46,7 @@ mutable struct MatrixEpiPerSquare{T <: Real, R <: RealOrComplex{T}} <: Cone{T}
     U::Hermitian{R, Matrix{R}}
     W::Matrix{R}
     Z::Hermitian{R, Matrix{R}}
-    fact_Z::Any
+    fact_Z::Cholesky{R, Matrix{R}}
     Zi::Hermitian{R, Matrix{R}}
     ZiW::Matrix{R}
     ZiUZi::Hermitian{R, Matrix{R}}

--- a/src/Cones/possemideftri.jl
+++ b/src/Cones/possemideftri.jl
@@ -38,7 +38,7 @@ mutable struct PosSemidefTri{T <: Real, R <: RealOrComplex{T}} <: Cone{T}
     mat3::Matrix{R}
     mat4::Matrix{R}
     inv_mat::Matrix{R}
-    fact_mat::Cholesky{R}
+    fact_mat::Cholesky{R, Matrix{R}}
 
     function PosSemidefTri{T, R}(dim::Int) where {T <: Real, R <: RealOrComplex{T}}
         @assert dim >= 1

--- a/src/Cones/possemideftrisparse/cholmodimpl.jl
+++ b/src/Cones/possemideftrisparse/cholmodimpl.jl
@@ -29,26 +29,26 @@ struct PSDSparseCholmod <: PSDSparseImpl end
 
 mutable struct PSDSparseCholmodCache{T <: BlasReal, R <: RealOrComplex{T}} <:
                PSDSparseCache{T, R}
-    sparse_point::Any
-    sparse_point_map::Any
-    symb_mat::Any
-    supers::Any
-    super_map::Any
-    parents::Any
-    ancestors::Any
-    num_cols::Any
-    num_rows::Any
-    J_rows::Any
-    L_idxs::Any
-    F_blocks::Any
-    L_blocks::Any
-    S_blocks::Any
-    L_pr_blocks::Any
-    S_pr_blocks::Any
-    L_pr_pr_blocks::Any
-    map_blocks::Any
-    temp_blocks::Any
-    rel_idxs::Any
+    sparse_point::CHOLMOD.Sparse{R, Int}
+    sparse_point_map::Vector{Int}
+    symb_mat::CHOLMOD.Factor{R, Int}
+    supers::Vector{Int}
+    super_map::Vector{Int}
+    parents::Vector{Int}
+    ancestors::Vector{Vector{Int}}
+    num_cols::Vector{Int}
+    num_rows::Vector{Int}
+    J_rows::Vector{Vector{Int}}
+    L_idxs::Vector{UnitRange{Int}}
+    F_blocks::Vector{Matrix{R}}
+    L_blocks::Vector{Matrix{R}}
+    S_blocks::Vector{Matrix{R}}
+    L_pr_blocks::Vector{Matrix{R}}
+    S_pr_blocks::Vector{Matrix{R}}
+    L_pr_pr_blocks::Vector{Matrix{R}}
+    map_blocks::Vector{Tuple{Int, Int, Int, Bool, Bool}}
+    temp_blocks::Vector{Matrix{R}}
+    rel_idxs::Vector{Vector{Tuple{Int, Int}}}
     PSDSparseCholmodCache{T, R}() where {T <: BlasReal, R <: RealOrComplex{T}} = new{T, R}()
 end
 
@@ -128,7 +128,7 @@ function setup_extra_data!(
     num_cols = cache.num_cols = Vector{Int}(undef, num_super)
     num_rows = cache.num_rows = Vector{Int}(undef, num_super)
     L_idxs = cache.L_idxs = Vector{UnitRange{Int}}(undef, num_super)
-    J_rows = cache.J_rows = Vector{Vector}(undef, num_super)
+    J_rows = cache.J_rows = Vector{Vector{Int}}(undef, num_super)
     F_blocks = cache.F_blocks = Vector{Matrix{R}}(undef, num_super)
     L_blocks = cache.L_blocks = Vector{Matrix{R}}(undef, num_super)
     L_pr_blocks = cache.L_pr_blocks = Vector{Matrix{R}}(undef, num_super)

--- a/src/Cones/possemideftrisparse/denseimpl.jl
+++ b/src/Cones/possemideftrisparse/denseimpl.jl
@@ -17,7 +17,7 @@ mutable struct PSDSparseDenseCache{T <: Real, R <: RealOrComplex{T}} <: PSDSpars
     mat::Matrix{R}
     mat2::Matrix{R}
     inv_mat::Matrix{R}
-    fact_mat::Any
+    fact_mat::Cholesky{R, Matrix{R}}
     PSDSparseDenseCache{T, R}() where {T <: Real, R <: RealOrComplex{T}} = new{T, R}()
 end
 

--- a/src/Cones/wsosinterpepinormone.jl
+++ b/src/Cones/wsosinterpepinormone.jl
@@ -42,7 +42,7 @@ mutable struct WSOSInterpEpiNormOne{T <: Real} <: Cone{T}
     hess_fact::Factorization{T}
 
     mats::Vector{Vector{Matrix{T}}}
-    matfact::Vector{Vector}
+    matfact::Vector{Vector{Cholesky{T, Matrix{T}}}}
     ΛLi_Λ::Vector{Vector{Matrix{T}}}
     Λ11::Vector{Matrix{T}}
     tempΛ11::Vector{Matrix{T}}
@@ -67,13 +67,13 @@ mutable struct WSOSInterpEpiNormOne{T <: Real} <: Cone{T}
     ΛLiP_dir12::Vector{Vector{Matrix{T}}}
     ΛLiP_dir21::Vector{Vector{Matrix{T}}}
     dder3_half::Vector{Vector{Matrix}}
-    Λfact::Vector
+    Λfact::Vector{Cholesky{T, Matrix{T}}}
     hess_edge_blocks::Vector{Matrix{T}}
     hess_diag_blocks::Vector{Matrix{T}}
-    hess_diag_facts::Vector
+    hess_diag_facts::Vector{Cholesky{T, Matrix{T}}}
     hess_diags::Vector{Matrix{T}}
     hess_schur_fact::Factorization{T}
-    point_views::Vector
+    point_views::Vector{SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int}}, true}}
     Ps_times::Vector{Float64}
     Ps_order::Vector{Int}
 
@@ -110,7 +110,7 @@ function setup_extra_data!(cone::WSOSInterpEpiNormOne{T}) where {T <: Real}
     cone.hess_edge_blocks = [zeros(T, U, U) for _ in 1:(R - 1)]
     cone.hess_diag_blocks = [zeros(T, U, U) for _ in 1:R]
     # TODO preallocate better
-    cone.hess_diag_facts = Any[cholesky(hcat([one(T)])) for _ in 1:(R - 1)]
+    cone.hess_diag_facts = [cholesky(hcat([one(T)])) for _ in 1:(R - 1)]
     cone.hess_diags = [zeros(T, U, U) for _ in 1:(R - 1)]
     cone.ΛLi_Λ = [[zeros(T, L, L) for _ in 1:(R - 1)] for L in Ls]
     cone.Λ11 = [zeros(T, L, L) for L in Ls]
@@ -134,7 +134,7 @@ function setup_extra_data!(cone::WSOSInterpEpiNormOne{T}) where {T <: Real}
     cone.ΛLiP_dir12 = [[zeros(T, L, U) for _ in 1:(R - 1)] for L in Ls]
     cone.ΛLiP_dir21 = [[zeros(T, L, U) for _ in 1:(R - 1)] for L in Ls]
     cone.dder3_half = [[zeros(T, 2 * L, 2 * U) for _ in 1:(R - 1)] for L in Ls]
-    cone.Λfact = Vector{Any}(undef, K)
+    cone.Λfact = Vector{Cholesky{T, Matrix{T}}}(undef, K)
     cone.point_views = [view(cone.point, block_idxs(U, i)) for i in 1:R]
     cone.Ps_times = zeros(K)
     cone.Ps_order = collect(1:K)

--- a/src/Cones/wsosinterpnonnegative.jl
+++ b/src/Cones/wsosinterpnonnegative.jl
@@ -44,7 +44,7 @@ mutable struct WSOSInterpNonnegative{T <: Real, R <: RealOrComplex{T}} <: Cone{T
     tempLU::Vector{Matrix{R}}
     ΛFLP::Vector{Matrix{R}}
     tempUU::Matrix{R}
-    ΛF::Vector
+    ΛF::Vector{Cholesky{R, Matrix{R}}}
     Ps_times::Vector{Float64}
     Ps_order::Vector{Int}
 
@@ -88,7 +88,7 @@ function setup_extra_data!(
     cone.ΛFLP = [zeros(R, L, dim) for L in Ls]
     cone.tempUU = zeros(R, dim, dim)
     K = length(Ls)
-    cone.ΛF = Vector{Any}(undef, K)
+    cone.ΛF = Vector{Cholesky{R, Matrix{R}}}(undef, K)
     cone.Ps_times = zeros(K)
     cone.Ps_order = collect(1:K)
     return cone

--- a/src/Cones/wsosinterppossemideftri.jl
+++ b/src/Cones/wsosinterppossemideftri.jl
@@ -47,11 +47,13 @@ mutable struct WSOSInterpPosSemidefTri{T <: Real} <: Cone{T}
     tempLRLR::Vector{Symmetric{T, Matrix{T}}}
     tempLRLR2::Vector{Matrix{T}}
     tempLRUR::Vector{Matrix{T}}
-    ΛFL::Vector
+    ΛFL::Vector{Cholesky{T, Matrix{T}}}
     ΛFLP::Vector{Matrix{T}}
     tempLU::Vector{Matrix{T}}
     PΛiP::Matrix{T}
-    PΛiP_blocks_U::Any
+    PΛiP_blocks_U::Matrix{
+        SubArray{T, 2, Matrix{T}, Tuple{UnitRange{Int}, UnitRange{Int}}, false},
+    }
     Ps_times::Vector{Float64}
     Ps_order::Vector{Int}
 
@@ -100,7 +102,7 @@ function setup_extra_data!(cone::WSOSInterpPosSemidefTri{T}) where {T <: Real}
     cone.tempLRLR2 = [zeros(T, L * R, L * R) for L in Ls]
     cone.tempLRUR = [zeros(T, L * R, U * R) for L in Ls]
     cone.tempLU = [zeros(T, L, U) for L in Ls]
-    cone.ΛFL = Vector{Any}(undef, K)
+    cone.ΛFL = Vector{Cholesky{T, Matrix{T}}}(undef, K)
     cone.ΛFLP = [zeros(T, R * L, R * U) for L in Ls]
     cone.PΛiP = zeros(T, R * U, R * U)
     cone.PΛiP_blocks_U =


### PR DESCRIPTION
While debugging some type instability in the QKD cone, I realized that Hypatia uses a lot of abstract types unnecessarily in the cones. I'm making them concrete here. In the QKD cone this simple change dramatically increased performance, about 25% speedup.

I didn't remove the abstract types from the LMI cone because that would require a redesign, and from the sparse PSD cone because I don't understand what is going on there.

Also several cones use an abstract `hess_fact`, which I don't understand why, as far as I can see it is always a Cholesky, no?