### PR TITLE
precise central point for relative entropy

### DIFF
--- a/src/Cones/epitrrelentropytri.jl
+++ b/src/Cones/epitrrelentropytri.jl
@@ -162,7 +162,7 @@ function set_initial_point!(
     incr = (cone.is_complex ? 2 : 1)
     arr .= 0
     # at the initial point V and W are diagonal, equivalent to epirelentropy
-    (arr[1], v, w) = get_central_ray_epirelentropy(cone.d)
+    (arr[1], v, w) = get_central_ray_epirelentropy(T(cone.d))
     k = 1
     for i in 1:(cone.d)
         arr[1 + k] = v


### PR DESCRIPTION
I've replaced the rough approximation for the central point used for the relative entropy cones with a precise numerical solution. One can eliminate `u` and `v`, leaving a single equation for `w`, which can then be solved via Newton's method in a couple of iterations. As a seed I'm using the asymptotic solution.