### PR TITLE
precise central point for logarithm

### DIFF
--- a/src/Cones/epirelentropy.jl
+++ b/src/Cones/epirelentropy.jl
@@ -392,7 +392,7 @@ function get_central_ray_epirelentropy(d::T) where {T <: AbstractFloat}
     counter = 0
     while counter < maxiter
         counter += 1
-        step = newton_ratio(w2, d)
+        step = _newton_ratio_relent(w2, d)
         w2 -= step
         if abs(step) < tol
             break
@@ -407,7 +407,7 @@ function get_central_ray_epirelentropy(d::T) where {T <: AbstractFloat}
     return u, v, w
 end
 
-function newton_ratio(w2, d)
+function _newton_ratio_relent(w2, d)
     rt = sqrt(w2 + d * w2 * (1 - w2) + d^2 * w2^2 / 4)
     v2 = 1 - d * w2 / 2 + rt
     f = 1 + (w2 - 1) / (v2 - 1) + log(w2 / v2) / 2

--- a/src/Cones/epirelentropy.jl
+++ b/src/Cones/epirelentropy.jl
@@ -404,7 +404,7 @@ function get_central_ray_epirelentropy(d::T) where {T <: AbstractFloat}
     v = sqrt(1 - d * w2 / 2 + rt)
     D = d * w * log(w / v)
     u = D / 2 + sqrt(1 + D^2 / 4)
-    return u, v, w
+    return (u, v, w)
 end
 
 function _newton_ratio_relent(w2, d)

--- a/src/Cones/hypoperlog.jl
+++ b/src/Cones/hypoperlog.jl
@@ -291,7 +291,7 @@ function get_central_ray_hypoperlog(d::T) where {T <: AbstractFloat}
     counter == maxiter && error("Failed to compute initial point.")
     u = v * d / 2 - sqrt(2 + v^2 * (d^2 / 4 - 1))
     w = sqrt(1 - u * v)
-    return u, v, w
+    return (u, v, w)
 end
 
 function _newton_ratio_log(v, d)

--- a/src/Cones/hypoperlog.jl
+++ b/src/Cones/hypoperlog.jl
@@ -54,8 +54,8 @@ end
 
 get_nu(cone::HypoPerLog) = cone.dim
 
-function set_initial_point!(arr::AbstractVector, cone::HypoPerLog)
-    (arr[1], arr[2], w) = get_central_ray_hypoperlog(cone.dim - 2)
+function set_initial_point!(arr::AbstractVector, cone::HypoPerLog{T}) where {T <: Real}
+    (arr[1], arr[2], w) = get_central_ray_hypoperlog(T(cone.dim - 2))
     @views arr[3:end] .= w
     return arr
 end
@@ -275,36 +275,33 @@ function dder3(cone::HypoPerLog{T}, dir::AbstractVector{T}) where {T <: Real}
     return dder3
 end
 
-# see analysis in
-# https://github.com/lkapelevich/HypatiaSupplements.jl/tree/master/centralpoints
-function get_central_ray_hypoperlog(d::Int)
-    if d <= 10
-        # lookup points where x = f'(x)
-        return central_rays_hypoperlog[d, :]
+function get_central_ray_hypoperlog(d::T) where {T <: AbstractFloat}
+    v = 0.553978 + 0.251124 / d
+    tol = sqrt(eps(T))
+    maxiter = 2ceil(log2(-log2(tol)))
+    counter = 0
+    while counter < maxiter
+        counter += 1
+        step = _newton_ratio_log(v, d)
+        v -= step
+        if abs(step) < tol
+            break
+        end
     end
-    # use nonlinear fit for higher dimensions
-    x = inv(d)
-    if d <= 70
-        u = 4.657876 * x^2 - 3.116192 * x + 0.000647
-        v = 0.424682 * x + 0.553392
-        w = 0.760412 * x + 1.001795
-    else
-        u = -3.011166 * x - 0.000122
-        v = 0.395308 * x + 0.553955
-        w = 0.837545 * x + 1.000024
-    end
-    return [u, v, w]
+    counter == maxiter && error("Failed to compute initial point.")
+    u = v * d / 2 - sqrt(2 + v^2 * (d^2 / 4 - 1))
+    w = sqrt(1 - u * v)
+    return u, v, w
 end
 
-const central_rays_hypoperlog = [
-    -0.827838387 0.805102007 1.290927686
-    -0.689607388 0.724605082 1.224617936
-    -0.584372665 0.68128058 1.182421942
-    -0.503499342 0.65448622 1.153053152
-    -0.440285893 0.636444224 1.131466926
-    -0.389979809 0.623569352 1.114979519
-    -0.349255921 0.613978276 1.102013921
-    -0.315769104 0.606589839 1.091577908
-    -0.287837744 0.600745284 1.083013
-    -0.264242734 0.596019009 1.075868782
-]
+function _newton_ratio_log(v, d)
+    rt = sqrt(2 + v^2 * (d^2 / 4 - 1))
+    u = v * d / 2 - rt
+    f = v^2 - 1 + u * v * d * (log((1 - u * v) / v^2) / 2 - 1)
+    du = d / 2 - v * (d^2 / 4 - 1) / rt
+    df =
+        2 * v +
+        d * (v * du + u) * (log((1 - u * v) / v^2) / 2 - 1) +
+        u * d * (-2 + u * v - v^2 * du) / (2 - 2 * u * v)
+    return f / df
+end

--- a/src/Cones/hypoperlogdettri.jl
+++ b/src/Cones/hypoperlogdettri.jl
@@ -84,7 +84,7 @@ function set_initial_point!(
 ) where {T <: Real, R <: RealOrComplex{T}}
     arr .= 0
     # central point data are the same as for hypoperlog
-    (arr[1], arr[2], w) = get_central_ray_hypoperlog(cone.d)
+    (arr[1], arr[2], w) = get_central_ray_hypoperlog(T(cone.d))
     incr = (cone.is_complex ? 2 : 1)
     k = 3
     @inbounds for i in 1:(cone.d)


### PR DESCRIPTION
Like in the relative entropy case, one can eliminate `w` and `u`, ending up with an equation on `v` only, that can be solved by Newton's method.